### PR TITLE
exit after help message

### DIFF
--- a/src/ImageServer/ImageServer.cpp
+++ b/src/ImageServer/ImageServer.cpp
@@ -18,6 +18,9 @@ namespace bfs = boost::filesystem;
 
 FS::ImageServer::ImageServer(int argc, char ** argv) {
 
+  // Task 1: exit after help. Insert a flag after help, if that
+  // flag exists then exit the program in main; return 0.
+
 	const std::string help = "--help";
 	if (argc < 2) 
 	{ // settings file not specified, use default
@@ -27,6 +30,8 @@ FS::ImageServer::ImageServer(int argc, char ** argv) {
 		if (argv[1] == help) {
 			#include STR(L10N_LANG)
 			std::wcout << rstr_help << std::endl;
+			throw std::invalid_argument
+			  ("End of help docs\n");
 		} else {
 			settings_path_ = argv[1];
 		}

--- a/src/ImageServer/ImageServerTest.cpp
+++ b/src/ImageServer/ImageServerTest.cpp
@@ -1,16 +1,24 @@
-
+#include <iostream>
 #include "ImageServer.h"
 
 // PManandhar note: not preferred, used for demo
 // or short files
 using namespace LMFocusStack;
+using namespace std;
 
 int main(int argc, char ** argv) {
 
+  try {
 	ImageServer server(argc, argv);
 
-
 	return 0;
-
+	
+  }
+  catch (exception &e) {
+    // Tyler note: http://isocpp.org/wiki/faq/exceptions#ctors-can-throw
+        std::cerr << "Program closing: " << e.what();
+        return -1;
+  }
+ 
 }
 


### PR DESCRIPTION
Here's my initial thoughts on the "Exit after help message" task. I threw an exception, caught it & closed the program by returning -1 in the test file. An alternative is to put the object into a 'zombie' and add a method to check it's state. Let me know what you think, thanks. 

References:
[std::invalid_argument](http://en.cppreference.com/w/cpp/error/invalid_argument)
[FAQ: How can I handle a constructor that fails?](http://isocpp.org/wiki/faq/exceptions#ctors-can-throw)
