### PR TITLE
Moved help feature to main

### DIFF
--- a/src/ImageServer/ImageServer.cpp
+++ b/src/ImageServer/ImageServer.cpp
@@ -17,24 +17,13 @@ namespace FS = LMFocusStack;
 namespace bfs = boost::filesystem;
 
 FS::ImageServer::ImageServer(int argc, char ** argv) {
-
-  // Task 1: exit after help. Insert a flag after help, if that
-  // flag exists then exit the program in main; return 0.
-
-	const std::string help = "--help";
+  
 	if (argc < 2) 
 	{ // settings file not specified, use default
 		this->settings_path_ = def_settings_;
 	} 
 	else { // load settings or display help
-		if (argv[1] == help) {
-			#include STR(L10N_LANG)
-			std::wcout << rstr_help << std::endl;
-			throw std::invalid_argument
-			  ("End of help docs\n");
-		} else {
-			settings_path_ = argv[1];
-		}
+		settings_path_ = argv[1];
 	} 
 	load_settings(); // could throw invalid settings exception
 }

--- a/src/ImageServer/ImageServerTest.cpp
+++ b/src/ImageServer/ImageServerTest.cpp
@@ -1,11 +1,8 @@
 #include <iostream>
 #include "ImageServer.h"
-#include <boost/filesystem.hpp>
 
 #define STR_EXPAND(tok) #tok
 #define STR(tok) STR_EXPAND(tok)
-
-namespace bfs = boost::filesystem;
 
 // PManandhar note: not preferred, used for demo
 // or short files
@@ -30,7 +27,7 @@ int options(char ** argv) {
 
 int main(int argc, char ** argv) {
   
-  if (options(argv) == -1){
+  if (argc >= 2 && options(argv) == -1){
     std::cout << "Program closing" << std::endl;
 
     return -1;

--- a/src/ImageServer/ImageServerTest.cpp
+++ b/src/ImageServer/ImageServerTest.cpp
@@ -1,24 +1,45 @@
 #include <iostream>
 #include "ImageServer.h"
+#include <boost/filesystem.hpp>
+
+#define STR_EXPAND(tok) #tok
+#define STR(tok) STR_EXPAND(tok)
+
+namespace bfs = boost::filesystem;
 
 // PManandhar note: not preferred, used for demo
 // or short files
 using namespace LMFocusStack;
 using namespace std;
 
-int main(int argc, char ** argv) {
-
-  try {
-	ImageServer server(argc, argv);
-
-	return 0;
-	
+int options(char ** argv) {
+  // Task 1.1: exit after help. Insert a flag after help, if that
+  // flag exists then exit the program in main; return 0.
+  // (Try to do this in the main function)
+  
+  const std::string help = "--help";
+  if (argv[1] == help) {
+    #include STR(L10N_LANG)
+    std::wcout << rstr_help << std::endl;
+    return -1;
   }
-  catch (exception &e) {
-    // Tyler note: http://isocpp.org/wiki/faq/exceptions#ctors-can-throw
-        std::cerr << "Program closing: " << e.what();
-        return -1;
+  else {
+    return 0;
   }
- 
 }
 
+int main(int argc, char ** argv) {
+  
+  if (options(argv) == -1){
+    std::cout << "Program closing" << std::endl;
+
+    return -1;
+    
+  }
+  else {
+    ImageServer server(argc, argv);
+    
+    return 0;
+  }
+    
+}

--- a/src/ImageServer/Makefile
+++ b/src/ImageServer/Makefile
@@ -17,6 +17,7 @@ ImageServer: ImageServer.cpp ImageServer.h
 			-c ImageServer.cpp -o ImageServer.o
 
 ImageServerTest: ImageServer ImageServerTest.cpp
-	$(CC) $(CFLAGS) ImageServerTest.cpp ImageServer.o -o ImageServerTest
+	$(CC) $(CFLAGS) -DL10N_LANG=$(L10N_FILE) \
+	ImageServerTest.cpp ImageServer.o -o ImageServerTest
 
 


### PR DESCRIPTION
This moves '--help' from LMFocusStack to main. It no longer throws and catches an exception when help is called. Modified the Makefile so it compiles correctly.  Added an options( ) function above main to give us flexibility if we want to handle other settings before instantiating LMFocusStack.
